### PR TITLE
Removing extra slash

### DIFF
--- a/bin/control
+++ b/bin/control
@@ -271,8 +271,8 @@ function deploy() {
   # if repo/deployments has any files in it, sync them to $WILDFLY_DEPLOYMENTS_DIR
   # and delete any files in $WILDFLY_DEPLOYMENTS_DIR that don't exist in
   # repo/deployments
-  if [ "$(ls ${OPENSHIFT_REPO_DIR}/deployments)" ]; then
-    rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}/deployments/ $WILDFLY_DEPLOYMENTS_DIR
+  if [ "$(ls ${OPENSHIFT_REPO_DIR}deployments)" ]; then
+    rsync -r --delete --exclude ".*" ${OPENSHIFT_REPO_DIR}deployments/ $WILDFLY_DEPLOYMENTS_DIR
   fi
 }
 


### PR DESCRIPTION
When the CI tool tries to deploy, the following error is shown:

`remote: ls: cannot access /var/lib/openshift/*****/app-root/runtime/repo//deployments: No such file or directory`
Reference: https://travis-ci.org/equipe-daca/projeto/builds/147084960